### PR TITLE
Security vulnerability

### DIFF
--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -15,3 +15,4 @@ This list is only for people who have had a pull request accepted. If that could
 - JuliusDeBoer
 - mybearworld (🐻)
 - JustDoom (Ian)
+- TheGatesDev (Tim)!


### PR DESCRIPTION
Not having me in the contributor list causes nDreamBerd to be vulnerable
Please fix asap-

Steps to reproduce:
- Head to [this page](https://www.dreamberd.computer/contributors/)
- TheGatesDev is not found in the contributors list
- nDreamBerd is vulnerable

Expected result:
- TheGatesDev is found in the contributors list
- nDreamBerd is not vulnerable

Additional info:
- Processor: Intel(R) Core(TM) i5-7300U CPU @ 2.60GHz   2.71 GHz
- RAM: 16,0 GB
- Operating system: Windows 10 Pro version 22H2

About the fix:
- Added TheGatesDev, and their go-to name to the contributors/readme.md file

Have a nice day!