### PR TITLE
Add missing contributor to the hALL oF fAME

### DIFF
--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -26,3 +26,4 @@ This list is only for people who have had a pull request accepted. If that could
 - Gears (⚙️, but plural)
 - Mikail
 - umgefahren
+- pIPYTHONMC


### PR DESCRIPTION
Self explanatory PR. For more details, see the commit.