### PR TITLE
make image "work in lightmode"

### DIFF
--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -34,6 +34,6 @@ This list is only for people who have had a pull request accepted. If that could
 - maeek (Maciej)
 - Karol Stawowski
 - 8bitsquid
-- <img src="https://github.com/TodePond/nDreamBerd/assets/13833017/c6fc7c10-c751-4bd9-b789-6e8664bbfbfa" height="16px" width="59px">
+- <img alt="alifeee" src="https://github.com/TodePond/nDreamBerd/assets/13833017/aad115f5-0d9d-4d19-9d07-ef9ef510b3a1" height="16px" width="59px">
 - 12emin34
 - R74n


### PR DESCRIPTION
closes #530

this was the best way I could think, without an ugly background image, or a [weird outline](https://forums.terraria.org/index.php?threads/best-cursor-colour.25517/)

I also wanted it to work on the github readme dark mode page

new image

https://github.com/alifeee/nDreamBerd/tree/patch-2/docs/contributors

![image](https://github.com/TodePond/nDreamBerd/assets/13833017/d04ff0b5-a448-4a2a-95b5-d62ae6681d1a)
